### PR TITLE
Ruby 3.x compatibility

### DIFF
--- a/lib/youtube_rails.rb
+++ b/lib/youtube_rails.rb
@@ -14,17 +14,17 @@ class YouTubeRails
   end
 
   def self.extract_video_id(youtube_url)
-   return nil if has_invalid_chars?(youtube_url)
+    return nil if has_invalid_chars?(youtube_url)
 
-   URL_FORMATS.values.inject(nil) do |result, format_regex|
-     match = format_regex.match(youtube_url)
-     match ? match[:id] : result
-   end
- end
+    URL_FORMATS.values.inject(nil) do |result, format_regex|
+      match = format_regex.match(youtube_url)
+      match ? match[:id] : result
+    end
+  end
 
- def self.youtube_embed_url(youtube_url, width = 420, height = 315, **options)
-   %(<iframe width="#{width}" height="#{height}" src="#{ youtube_embed_url_only(youtube_url, options) }" frameborder="0" allowfullscreen></iframe>)
- end
+  def self.youtube_embed_url(youtube_url, width = 420, height = 315, **options)
+    %(<iframe width="#{width}" height="#{height}" src="#{ youtube_embed_url_only(youtube_url, options) }" frameborder="0" allowfullscreen></iframe>)
+  end
 
   def self.youtube_regular_url(youtube_url, **options)
     vid_id = extract_video_id(youtube_url)

--- a/lib/youtube_rails.rb
+++ b/lib/youtube_rails.rb
@@ -23,7 +23,7 @@ class YouTubeRails
   end
 
   def self.youtube_embed_url(youtube_url, width = 420, height = 315, **options)
-    %(<iframe width="#{width}" height="#{height}" src="#{ youtube_embed_url_only(youtube_url, options) }" frameborder="0" allowfullscreen></iframe>)
+    %(<iframe width="#{width}" height="#{height}" src="#{ youtube_embed_url_only(youtube_url, **options) }" frameborder="0" allowfullscreen></iframe>)
   end
 
   def self.youtube_regular_url(youtube_url, **options)


### PR DESCRIPTION
This PR does two things:

1. Adds the double splat operator (`**`) to the `options` argument making the gem compatible with Ruby 3.x
2. Fixes indentation to remove test warnings